### PR TITLE
[codestyle] Fixed first letter casing in method names

### DIFF
--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -62,11 +62,11 @@ class LdapClientTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * Test...
 	 *
-	 * @todo Implement testSetDN().
+	 * @todo Implement testSetDn().
 	 *
 	 * @return void
 	 */
-	public function testSetDN()
+	public function testSetDn()
 	{
 		// Remove the following lines when you implement this test.
 		$this->markTestIncomplete('This test has not been implemented yet.');
@@ -75,11 +75,11 @@ class LdapClientTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * Test...
 	 *
-	 * @todo Implement testGetDN().
+	 * @todo Implement testGetDn().
 	 *
 	 * @return void
 	 */
-	public function testGetDN()
+	public function testGetDn()
 	{
 		// Remove the following lines when you implement this test.
 		$this->markTestIncomplete('This test has not been implemented yet.');
@@ -283,11 +283,11 @@ class LdapClientTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * Test...
 	 *
-	 * @todo Implement testLDAPNetAddr().
+	 * @todo Implement testLdapNetAddr().
 	 *
 	 * @return void
 	 */
-	public function testLDAPNetAddr()
+	public function testLdapNetAddr()
 	{
 		// Remove the following lines when you implement this test.
 		$this->markTestIncomplete('This test has not been implemented yet.');

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -192,7 +192,7 @@ class LdapClient
 	 *
 	 * @since   1.0
 	 */
-	public function setDN($username, $nosub = 0)
+	public function setDn($username, $nosub = 0)
 	{
 		if ($this->users_dn == '' || $nosub)
 		{
@@ -215,7 +215,7 @@ class LdapClient
 	 *
 	 * @since   1.0
 	 */
-	public function getDN()
+	public function getDn()
 	{
 		return $this->dn;
 	}
@@ -257,8 +257,8 @@ class LdapClient
 			$password = $this->password;
 		}
 
-		$this->setDN($username, $nosub);
-		$bindResult = @ldap_bind($this->resource, $this->getDN(), $password);
+		$this->setDn($username, $nosub);
+		$bindResult = @ldap_bind($this->resource, $this->getDn(), $password);
 
 		return $bindResult;
 	}
@@ -570,7 +570,7 @@ class LdapClient
 	 * @author  Jay Burrell, Systems & Networks, Mississippi State University
 	 * @since   1.0
 	 */
-	public static function LDAPNetAddr($networkaddress)
+	public static function LdapNetAddr($networkaddress)
 	{
 		$addr = "";
 		$addrtype = (int) substr($networkaddress, 0, 1);


### PR DESCRIPTION
This PR fixes some more method names to comply with the CamelCase rules mentioned here:
http://joomla.github.io/coding-standards/?coding-standards/chapters/php.md
> ...be written in CamelCase even if using traditionally uppercase acronyms (such as XML, HTML).

Not touching casing of class names as this requires changes in casing in file names and causes issues at this point.