### PR TITLE
Added escape method to LdapClient

### DIFF
--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -506,6 +506,20 @@ class LdapClient
 	}
 
 	/**
+	 * Escape a string
+	 *
+	 * @param   string  $value   The subject string
+	 * @param   string  $ignore  Characters to ignore when escaping.
+	 * @param   int     $flags   The context the escaped string will be used in LDAP_ESCAPE_FILTER or LDAP_ESCAPE_DN
+	 *
+	 * @return string
+	 */
+	public function escape($value, $ignore = '', $flags = 0)
+	{
+		return @ldap_escape($value, $ignore, $flags);
+	}
+
+	/**
 	 * Returns the error message
 	 *
 	 * @return  string   error message


### PR DESCRIPTION
See http://php.net/manual/de/function.ldap-escape.php for details on the acutal method. So far it was missing in the client.
