### PR TITLE
Test the client, API improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ matrix:
 before_install:
   - mkdir /tmp/slapd
   - slapd -f .travis/ldap/conf/slapd.conf -h ldap://localhost:3389 &
-  - ldapadd -h localhost:3389 -D cn=admin,dc=joomla,dc=org -w joomla -f .travis/ldap/data/base.ldif && ldapadd -h localhost:3389 -D cn=admin,dc=joomla,dc=org -w joomla -f .travis/ldap/data/fixtures.ldif
+  - ldapadd -h localhost:3389 -D cn=admin,dc=joomla,dc=org -w joomla -f .travis/ldap/data/base.ldif
+  - ldapadd -h localhost:3389 -D cn=admin,dc=joomla,dc=org -w joomla -f .travis/ldap/data/fixtures.ldif
 
 before_script:
   # The Trusty build is compiled with LDAP support

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,13 @@ matrix:
     - php: 7.2
     - php: nightly
 
+before_install:
+  - mkdir /tmp/slapd
+  - slapd -f .travis/ldap/conf/slapd.conf -h ldap://localhost:3389 &
+  - ldapadd -h localhost:3389 -D cn=admin,dc=joomla,dc=org -w joomla -f .travis/ldap/data/base.ldif && ldapadd -h localhost:3389 -D cn=admin,dc=joomla,dc=org -w joomla -f .travis/ldap/data/fixtures.ldif
+
 before_script:
-    # The Trusty build is compiled with LDAP support
+  # The Trusty build is compiled with LDAP support
   - if [[ $TRAVIS_PHP_VERSION = 5.3 ]]; then phpenv config-add .travis/phpenv/ldap.ini; fi
   - composer self-update
   - composer update $COMPOSER_FLAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ matrix:
 before_install:
   - mkdir /tmp/slapd
   - slapd -f .travis/ldap/conf/slapd.conf -h ldap://localhost:3389 &
+  # This sleep is required to ensure the slapd process is running before loading the data in
+  - sleep 3
   - ldapadd -h localhost:3389 -D cn=admin,dc=joomla,dc=org -w joomla -f .travis/ldap/data/base.ldif
   - ldapadd -h localhost:3389 -D cn=admin,dc=joomla,dc=org -w joomla -f .travis/ldap/data/fixtures.ldif
 

--- a/.travis/ldap/conf/slapd.conf
+++ b/.travis/ldap/conf/slapd.conf
@@ -14,4 +14,4 @@ directory /tmp/slapd
 
 suffix    "dc=joomla,dc=org"
 rootdn    "cn=admin,dc=joomla,dc=org"
-rootpw    {SSHA}9Y0x1y7zv4nyND8/OmucDXnOia4a4+LF
+rootpw    {SSHA}kmwklAp1MLJT2ULJC3s9Ry3vo7XUrqj4

--- a/.travis/ldap/conf/slapd.conf
+++ b/.travis/ldap/conf/slapd.conf
@@ -1,0 +1,17 @@
+# See slapd.conf(5) for details on configuration options.
+include   /etc/ldap/schema/core.schema
+include   /etc/ldap/schema/cosine.schema
+include   /etc/ldap/schema/inetorgperson.schema
+include   /etc/ldap/schema/nis.schema
+
+pidfile  /tmp/slapd/slapd.pid
+argsfile /tmp/slapd/slapd.args
+
+modulepath /usr/lib/openldap
+
+database  ldif
+directory /tmp/slapd
+
+suffix    "dc=joomla,dc=org"
+rootdn    "cn=admin,dc=joomla,dc=org"
+rootpw    {SSHA}9Y0x1y7zv4nyND8/OmucDXnOia4a4+LF

--- a/.travis/ldap/data/base.ldif
+++ b/.travis/ldap/data/base.ldif
@@ -1,0 +1,4 @@
+dn: dc=joomla,dc=org
+objectClass: dcObject
+objectClass: organizationalUnit
+ou: Organization

--- a/.travis/ldap/data/fixtures.ldif
+++ b/.travis/ldap/data/fixtures.ldif
@@ -1,0 +1,24 @@
+dn: cn=Michael Babker,dc=joomla,dc=org
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Michael Babker
+sn: mbabker
+mail: michael.babker@joomla.org
+ou: People
+ou: Maintainers
+givenName: Michael Babker
+description: Framework Maintainer, CMS Release Lead, Production Department Coordinator
+
+dn: ou=Components,dc=joomla,dc=org
+objectclass: organizationalunit
+ou: Components
+
+dn: ou=Ldap,ou=Components,dc=joomla,dc=org
+objectclass: organizationalunit
+ou: Ldap
+
+dn: ou=Ldap scoping,ou=Ldap,ou=Components,dc=joomla,dc=org
+objectclass: organizationalunit
+ou: Ldap scoping

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -237,46 +237,95 @@ class LdapClientTest extends TestCase
 			$this->markTestSkipped('Could not bind to LDAP server');
 		}
 
-		var_dump($this->object->replace('cn=Michael Babker,dc=joomla,dc=org', array('mail' => 'michael@joomla.org')));
+		$this->assertTrue($this->object->replace('cn=Michael Babker,dc=joomla,dc=org', array('mail' => 'michael@joomla.org')), 'The attribute was not replaced');
+
+		// Reset
+		$this->object->replace('cn=Michael Babker,dc=joomla,dc=org', array('mail' => 'michael.babker@joomla.org'));
 	}
 
 	/**
-	 * Test...
+	 * @testdox  An attribute is modified for the given user DN
 	 *
-	 * @todo Implement testModify().
-	 *
-	 * @return void
+	 * @covers  Joomla\Ldap\Ldap::modify
+	 * @uses    Joomla\Ldap\Ldap::bind
+	 * @uses    Joomla\Ldap\Ldap::connect
+	 * @uses    Joomla\Ldap\Ldap::setDn
 	 */
 	public function testModify()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		if (!$this->object->connect())
+		{
+			$this->markTestSkipped('Could not connect to LDAP server');
+		}
+
+		$this->object->base_dn  = 'dc=joomla,dc=org';
+		$this->object->users_dn = 'cn=[username],dc=joomla,dc=org';
+
+		if (!$this->object->bind('admin', 'joomla'))
+		{
+			$this->markTestSkipped('Could not bind to LDAP server');
+		}
+
+		$this->assertTrue($this->object->modify('cn=Michael Babker,dc=joomla,dc=org', array('mail' => 'michael@joomla.org')), 'The attribute was not modified');
+
+		// Reset
+		$this->object->modify('cn=Michael Babker,dc=joomla,dc=org', array('mail' => 'michael.babker@joomla.org'));
 	}
 
 	/**
-	 * Test...
+	 * @testdox  An attribute is removed from the given user DN
 	 *
-	 * @todo Implement testRemove().
-	 *
-	 * @return void
+	 * @covers  Joomla\Ldap\Ldap::remove
+	 * @uses    Joomla\Ldap\Ldap::add
+	 * @uses    Joomla\Ldap\Ldap::bind
+	 * @uses    Joomla\Ldap\Ldap::connect
+	 * @uses    Joomla\Ldap\Ldap::setDn
 	 */
 	public function testRemove()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		if (!$this->object->connect())
+		{
+			$this->markTestSkipped('Could not connect to LDAP server');
+		}
+
+		$this->object->base_dn  = 'dc=joomla,dc=org';
+		$this->object->users_dn = 'cn=[username],dc=joomla,dc=org';
+
+		if (!$this->object->bind('admin', 'joomla'))
+		{
+			$this->markTestSkipped('Could not bind to LDAP server');
+		}
+
+		$this->assertTrue($this->object->remove('cn=Michael Babker,dc=joomla,dc=org', array('mail' => 'michael@joomla.org')), 'The attribute was not removed');
+
+		// Reset
+		$this->object->add('cn=Michael Babker,dc=joomla,dc=org', array('mail' => 'michael.babker@joomla.org'));
 	}
 
 	/**
-	 * Test...
+	 * @testdox  An attribute is compared for a given value to the user DN
 	 *
-	 * @todo Implement testCompare().
-	 *
-	 * @return void
+	 * @covers  Joomla\Ldap\Ldap::compare
+	 * @uses    Joomla\Ldap\Ldap::bind
+	 * @uses    Joomla\Ldap\Ldap::connect
+	 * @uses    Joomla\Ldap\Ldap::setDn
 	 */
 	public function testCompare()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		if (!$this->object->connect())
+		{
+			$this->markTestSkipped('Could not connect to LDAP server');
+		}
+
+		$this->object->base_dn  = 'dc=joomla,dc=org';
+		$this->object->users_dn = 'cn=[username],dc=joomla,dc=org';
+
+		if (!$this->object->bind('admin', 'joomla'))
+		{
+			$this->markTestSkipped('Could not bind to LDAP server');
+		}
+
+		$this->assertTrue($this->object->compare('cn=Michael Babker,dc=joomla,dc=org', 'mail', 'michael@joomla.org'), 'The attribute value is not in the expected state');
 	}
 
 	/**

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -478,29 +478,62 @@ class LdapClientTest extends TestCase
 	}
 
 	/**
-	 * Test...
+	 * @testdox  An attribute is added to the given user DN
 	 *
-	 * @todo Implement testAdd().
-	 *
-	 * @return void
+	 * @covers  Joomla\Ldap\Ldap::add
+	 * @uses    Joomla\Ldap\Ldap::remove
+	 * @uses    Joomla\Ldap\Ldap::bind
+	 * @uses    Joomla\Ldap\Ldap::connect
+	 * @uses    Joomla\Ldap\Ldap::setDn
 	 */
 	public function testAdd()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		if (!$this->object->connect())
+		{
+			$this->markTestSkipped('Could not connect to LDAP server');
+		}
+
+		$this->object->base_dn  = 'dc=joomla,dc=org';
+		$this->object->users_dn = 'cn=[username],dc=joomla,dc=org';
+
+		if (!$this->object->bind('admin', 'joomla'))
+		{
+			$this->markTestSkipped('Could not bind to LDAP server');
+		}
+
+		$this->assertTrue($this->object->add('cn=Michael Babker,dc=joomla,dc=org', array('mail' => 'michael.babker@gmail.com')), 'The attribute was not added');
+
+		// Reset
+		$this->object->remove('cn=Michael Babker,dc=joomla,dc=org', array('mail' => 'michael.babker@gmail.com'));
 	}
 
 	/**
-	 * Test...
+	 * @testdox  An entry is renamed on the server based for the given DN
 	 *
-	 * @todo Implement testRename().
-	 *
-	 * @return void
+	 * @covers  Joomla\Ldap\Ldap::rename
+	 * @uses    Joomla\Ldap\Ldap::bind
+	 * @uses    Joomla\Ldap\Ldap::connect
+	 * @uses    Joomla\Ldap\Ldap::setDn
 	 */
 	public function testRename()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		if (!$this->object->connect())
+		{
+			$this->markTestSkipped('Could not connect to LDAP server');
+		}
+
+		$this->object->base_dn  = 'dc=joomla,dc=org';
+		$this->object->users_dn = 'cn=[username],dc=joomla,dc=org';
+
+		if (!$this->object->bind('admin', 'joomla'))
+		{
+			$this->markTestSkipped('Could not bind to LDAP server');
+		}
+
+		$this->assertTrue($this->object->rename('cn=Michael Babker,dc=joomla,dc=org', 'cn=Michael', null, true), 'The entry was not renamed');
+
+		// Reset
+		$this->object->rename('cn=Michael', 'cn=Michael Babker,dc=joomla,dc=org', null, true);
 	}
 
 	/**

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -85,11 +85,11 @@ class LdapClientTest extends TestCase
 	 */
 	public function testTheDnIsSetWhenThereIsAUserDn()
 	{
-		$this->object->users_dn = 'uid=[username],cn=admin,dc=joomla,dc=org';
+		$this->object->users_dn = 'cn=[username],dc=joomla,dc=org';
 
 		$this->object->setDn('admin');
 
-		$this->assertSame('uid=admin,cn=admin,dc=joomla,dc=org', $this->object->getDn());
+		$this->assertSame('cn=admin,dc=joomla,dc=org', $this->object->getDn());
 	}
 
 	/**
@@ -131,7 +131,9 @@ class LdapClientTest extends TestCase
 			$this->markTestSkipped('Could not connect to LDAP server');
 		}
 
-		$this->assertTrue($this->object->bind('cn=admin,dc=joomla,dc=org', 'joomla'), 'LDAP connection failed: ' . $this->object->getErrorMsg());
+		$this->object->users_dn = 'cn=[username],dc=joomla,dc=org';
+
+		$this->assertTrue($this->object->bind('admin', 'joomla'), 'LDAP connection failed: ' . $this->object->getErrorMsg());
 	}
 
 	/**

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -7,17 +7,16 @@
 namespace Joomla\Ldap\Tests;
 
 use Joomla\Ldap\LdapClient;
+use Joomla\Registry\Registry;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Test class for LdapClient.
- *
- * @since  1.0
+ * Test class for Joomla\Ldap\LdapClient.
  */
 class LdapClientTest extends TestCase
 {
 	/**
-	 * @var    LdapClient
+	 * @var  LdapClient
 	 */
 	protected $object;
 
@@ -31,20 +30,20 @@ class LdapClientTest extends TestCase
 	{
 		parent::setUp();
 
-		$this->object = new LdapClient;
+		$data = array(
+			'host' => getenv('LDAP_HOST') ?: '127.0.0.1',
+			'port' => getenv('LDAP_PORT') ?: '3389',
+		);
+
+		$this->object = new LdapClient(new Registry($data));
 	}
 
 	/**
-	 * Test...
-	 *
-	 * @todo Implement testConnect().
-	 *
-	 * @return void
+	 * @covers  Joomla\Ldap\Ldap::connect
 	 */
 	public function testConnect()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->assertTrue($this->object->connect());
 	}
 
 	/**

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -152,6 +152,7 @@ class LdapClientTest extends TestCase
 			$this->markTestSkipped('Could not connect to LDAP server');
 		}
 
+		$this->object->base_dn  = 'dc=joomla,dc=org';
 		$this->object->users_dn = 'cn=[username],dc=joomla,dc=org';
 
 		if (!$this->object->bind('admin', 'joomla'))

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -296,7 +296,7 @@ class LdapClientTest extends TestCase
 			$this->markTestSkipped('Could not bind to LDAP server');
 		}
 
-		$this->assertTrue($this->object->remove('cn=Michael Babker,dc=joomla,dc=org', array('mail' => 'michael@joomla.org')), 'The attribute was not removed');
+		$this->assertTrue($this->object->remove('cn=Michael Babker,dc=joomla,dc=org', array('mail' => '')), 'The attribute was not removed');
 
 		// Reset
 		$this->object->add('cn=Michael Babker,dc=joomla,dc=org', array('mail' => 'michael.babker@joomla.org'));
@@ -325,7 +325,7 @@ class LdapClientTest extends TestCase
 			$this->markTestSkipped('Could not bind to LDAP server');
 		}
 
-		$this->assertTrue($this->object->compare('cn=Michael Babker,dc=joomla,dc=org', 'mail', 'michael@joomla.org'), 'The attribute value is not in the expected state');
+		$this->assertTrue($this->object->compare('cn=Michael Babker,dc=joomla,dc=org', 'mail', 'michael.babker@joomla.org'), 'The attribute value is not in the expected state');
 	}
 
 	/**

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -54,16 +54,18 @@ class LdapClientTest extends TestCase
 	/**
 	 * @covers  Joomla\Ldap\Ldap::connect
 	 */
-	public function testConnect()
+	public function testTheConnectionIsOpened()
 	{
 		$this->assertTrue($this->object->connect());
 	}
 
 	/**
+	 * @testdox  The DN is set when there is no user DN
+	 *
 	 * @covers  Joomla\Ldap\Ldap::setDn
 	 * @uses    Joomla\Ldap\Ldap::getDn
 	 */
-	public function testSetDnWithNoUserDn()
+	public function testTheDnIsSetWhenThereIsNoUserDn()
 	{
 		$dn = 'cn=admin,dc=joomla,dc=org';
 
@@ -73,53 +75,57 @@ class LdapClientTest extends TestCase
 	}
 
 	/**
+	 * @testdox  The DN is set when there is a user DN
+	 *
 	 * @covers  Joomla\Ldap\Ldap::setDn
 	 * @uses    Joomla\Ldap\Ldap::getDn
 	 */
-	public function testSetDnWithUserDn()
+	public function testTheDnIsSetWhenThereIsAUserDn()
 	{
-		$this->object->setDn('uid=[username],cn=admin,dc=joomla,dc=org');
+		$this->object->users_dn = 'uid=[username],cn=admin,dc=joomla,dc=org';
+
 		$this->object->setDn('admin');
 
 		$this->assertSame('uid=admin,cn=admin,dc=joomla,dc=org', $this->object->getDn());
 	}
 
 	/**
+	 * @testdox  The DN is retrieved
+	 *
 	 * @covers  Joomla\Ldap\Ldap::getDn
 	 */
-	public function testGetDn()
+	public function testTheDnIsRetrieved()
 	{
 		$this->assertNull($this->object->getDn());
 	}
 
 	/**
-	 * Test...
+	 * @testdox  The connection is bound to the LDAP server anonymously
 	 *
-	 * @todo Implement testAnonymous_bind().
-	 *
-	 * @return void
+	 * @covers  Joomla\Ldap\Ldap::anonymous_bind
 	 */
-	public function testAnonymous_bind()
+	public function testAnonymousBinding()
+	{
+		$this->markTestSkipped('Not connecting correctly on Travis CI environment');
+	}
+
+	/**
+	 * @testdox  The connection is bound to the LDAP server
+	 *
+	 * @covers  Joomla\Ldap\Ldap::bind
+	 * @uses    Joomla\Ldap\Ldap::connect
+	 * @uses    Joomla\Ldap\Ldap::setDn
+	 */
+	public function testBinding()
 	{
 		if (!$this->object->connect())
 		{
 			$this->markTestSkipped('Could not connect to LDAP server');
 		}
 
-		var_dump($this->object->anonymous_bind());
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
-	}
+		$this->object->setDn('cn=admin,dc=joomla,dc=org');
 
-	/**
-	 * Test...
-	 *
-	 * @todo Implement testBind().
-	 *
-	 * @return void
-	 */
-	public function testBind()
-	{
+		var_dump($this->object->bind(null, 'joomla'));
 		// Remove the following lines when you implement this test.
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -30,10 +30,12 @@ class LdapClientTest extends TestCase
 	{
 		parent::setUp();
 
+		$v3 = getenv('LDAP_V3');
+
 		$data = array(
 			'host'       => getenv('LDAP_HOST') ?: '127.0.0.1',
 			'port'       => getenv('LDAP_PORT') ?: '3389',
-			'use_ldapV3' => (bool) getenv('LDAP_V3') ?: true,
+			'use_ldapV3' => $v3 === false ? true : (bool) $v3,
 		);
 
 		$this->object = new LdapClient(new Registry($data));

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -351,7 +351,7 @@ class LdapClientTest extends TestCase
 			$this->markTestSkipped('Could not bind to LDAP server');
 		}
 
-		var_dump($this->object->read('cn=Michael Babker,dc=joomla,dc=org'));
+		var_dump($this->object->read('(objectclass=*),dc=joomla,dc=org'));
 	}
 
 	/**

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -351,7 +351,7 @@ class LdapClientTest extends TestCase
 			$this->markTestSkipped('Could not bind to LDAP server');
 		}
 
-		$this->object->read('cn=Michael Babker,dc=joomla,dc=org');
+		var_dump($this->object->read('cn=Michael Babker,dc=joomla,dc=org'));
 	}
 
 	/**

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -296,7 +296,7 @@ class LdapClientTest extends TestCase
 			$this->markTestSkipped('Could not bind to LDAP server');
 		}
 
-		$this->assertTrue($this->object->remove('cn=Michael Babker,dc=joomla,dc=org', array('mail' => '')), 'The attribute was not removed');
+		$this->assertTrue($this->object->remove('cn=Michael Babker,dc=joomla,dc=org', array('mail' => 'michael.babker@joomla.org')), 'The attribute was not removed');
 
 		// Reset
 		$this->object->add('cn=Michael Babker,dc=joomla,dc=org', array('mail' => 'michael.babker@joomla.org'));

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -137,14 +137,29 @@ class LdapClientTest extends TestCase
 	}
 
 	/**
-	 * Test...
+	 * @testdox  A simple search is performed
 	 *
-	 * @todo Implement testSimple_search().
-	 *
-	 * @return void
+	 * @covers  Joomla\Ldap\Ldap::simple_search
+	 * @uses    Joomla\Ldap\Ldap::bind
+	 * @uses    Joomla\Ldap\Ldap::connect
+	 * @uses    Joomla\Ldap\Ldap::search
+	 * @uses    Joomla\Ldap\Ldap::setDn
 	 */
-	public function testSimple_search()
+	public function testSimpleSearch()
 	{
+		if (!$this->object->connect())
+		{
+			$this->markTestSkipped('Could not connect to LDAP server');
+		}
+
+		$this->object->users_dn = 'cn=[username],dc=joomla,dc=org';
+
+		if (!$this->object->bind('admin', 'joomla'))
+		{
+			$this->markTestSkipped('Could not bind to LDAP server');
+		}
+
+		var_dump($this->object->simple_search('objectclass=person'));
 		// Remove the following lines when you implement this test.
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -166,10 +166,9 @@ class LdapClientTest extends TestCase
 	/**
 	 * @testdox  A search is performed without an override of the base DN
 	 *
-	 * @covers  Joomla\Ldap\Ldap::simple_search
+	 * @covers  Joomla\Ldap\Ldap::search
 	 * @uses    Joomla\Ldap\Ldap::bind
 	 * @uses    Joomla\Ldap\Ldap::connect
-	 * @uses    Joomla\Ldap\Ldap::search
 	 * @uses    Joomla\Ldap\Ldap::setDn
 	 */
 	public function testSearchWithoutDnOverride()
@@ -193,10 +192,9 @@ class LdapClientTest extends TestCase
 	/**
 	 * @testdox  A search is performed with an override of the base DN
 	 *
-	 * @covers  Joomla\Ldap\Ldap::simple_search
+	 * @covers  Joomla\Ldap\Ldap::search
 	 * @uses    Joomla\Ldap\Ldap::bind
 	 * @uses    Joomla\Ldap\Ldap::connect
-	 * @uses    Joomla\Ldap\Ldap::search
 	 * @uses    Joomla\Ldap\Ldap::setDn
 	 */
 	public function testSearchWithDnOverride()
@@ -217,16 +215,29 @@ class LdapClientTest extends TestCase
 	}
 
 	/**
-	 * Test...
+	 * @testdox  An attribute is replaced for the given user DN
 	 *
-	 * @todo Implement testReplace().
-	 *
-	 * @return void
+	 * @covers  Joomla\Ldap\Ldap::replace
+	 * @uses    Joomla\Ldap\Ldap::bind
+	 * @uses    Joomla\Ldap\Ldap::connect
+	 * @uses    Joomla\Ldap\Ldap::setDn
 	 */
 	public function testReplace()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		if (!$this->object->connect())
+		{
+			$this->markTestSkipped('Could not connect to LDAP server');
+		}
+
+		$this->object->base_dn  = 'dc=joomla,dc=org';
+		$this->object->users_dn = 'cn=[username],dc=joomla,dc=org';
+
+		if (!$this->object->bind('admin', 'joomla'))
+		{
+			$this->markTestSkipped('Could not bind to LDAP server');
+		}
+
+		var_dump($this->object->replace('cn=Michael Babker,dc=joomla,dc=org', array('mail' => 'michael@joomla.org')));
 	}
 
 	/**

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -31,8 +31,9 @@ class LdapClientTest extends TestCase
 		parent::setUp();
 
 		$data = array(
-			'host' => getenv('LDAP_HOST') ?: '127.0.0.1',
-			'port' => getenv('LDAP_PORT') ?: '3389',
+			'host'       => getenv('LDAP_HOST') ?: '127.0.0.1',
+			'port'       => getenv('LDAP_PORT') ?: '3389',
+			'use_ldapV3' => (bool) getenv('LDAP_V3') ?: true,
 		);
 
 		$this->object = new LdapClient(new Registry($data));

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -416,16 +416,65 @@ class LdapClientTest extends TestCase
 	}
 
 	/**
-	 * Test...
+	 * @testdox  An entry is created on the server based for the given DN
 	 *
-	 * @todo Implement testCreate().
-	 *
-	 * @return void
+	 * @covers  Joomla\Ldap\Ldap::create
+	 * @uses    Joomla\Ldap\Ldap::bind
+	 * @uses    Joomla\Ldap\Ldap::connect
+	 * @uses    Joomla\Ldap\Ldap::delete
+	 * @uses    Joomla\Ldap\Ldap::setDn
 	 */
 	public function testCreate()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		if (!$this->object->connect())
+		{
+			$this->markTestSkipped('Could not connect to LDAP server');
+		}
+
+		$this->object->base_dn  = 'dc=joomla,dc=org';
+		$this->object->users_dn = 'cn=[username],dc=joomla,dc=org';
+
+		if (!$this->object->bind('admin', 'joomla'))
+		{
+			$this->markTestSkipped('Could not bind to LDAP server');
+		}
+
+		$this->assertTrue(
+			$this->object->create(
+				'cn=George Wilson,dc=joomla,dc=org',
+				array(
+					'objectClass' => array(
+						'inetOrgPerson',
+						'organizationalPerson',
+						'person',
+						'top',
+					),
+					'cn'          => array(
+						'George Wilson',
+					),
+					'sn'          => array(
+						'wilsonge',
+					),
+					'mail'        => array(
+						'george.wilson@joomla.org',
+					),
+					'ou'          => array(
+						'People',
+						'Maintainers',
+					),
+					'givenName'   => array(
+						'George Wilson',
+					),
+					'description' => array(
+						'Framework Team Lead',
+					),
+				)
+			),
+			'The entry was not created'
+		);
+
+		// Reset
+		$this->object->delete('cn=George Wilson,dc=joomla,dc=org');
 	}
 
 	/**

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -329,16 +329,29 @@ class LdapClientTest extends TestCase
 	}
 
 	/**
-	 * Test...
+	 * @testdox  A DN is read from the server and the attributes returned
 	 *
-	 * @todo Implement testRead().
-	 *
-	 * @return void
+	 * @covers  Joomla\Ldap\Ldap::read
+	 * @uses    Joomla\Ldap\Ldap::bind
+	 * @uses    Joomla\Ldap\Ldap::connect
+	 * @uses    Joomla\Ldap\Ldap::setDn
 	 */
 	public function testRead()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		if (!$this->object->connect())
+		{
+			$this->markTestSkipped('Could not connect to LDAP server');
+		}
+
+		$this->object->base_dn  = 'dc=joomla,dc=org';
+		$this->object->users_dn = 'cn=[username],dc=joomla,dc=org';
+
+		if (!$this->object->bind('admin', 'joomla'))
+		{
+			$this->markTestSkipped('Could not bind to LDAP server');
+		}
+
+		$this->object->read('cn=Michael Babker,dc=joomla,dc=org');
 	}
 
 	/**

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -357,16 +357,62 @@ class LdapClientTest extends TestCase
 	}
 
 	/**
-	 * Test...
+	 * @testdox  An entry is removed from the server based on the given DN
 	 *
-	 * @todo Implement testDelete().
-	 *
-	 * @return void
+	 * @covers  Joomla\Ldap\Ldap::delete
+	 * @uses    Joomla\Ldap\Ldap::bind
+	 * @uses    Joomla\Ldap\Ldap::connect
+	 * @uses    Joomla\Ldap\Ldap::create
+	 * @uses    Joomla\Ldap\Ldap::setDn
 	 */
 	public function testDelete()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		if (!$this->object->connect())
+		{
+			$this->markTestSkipped('Could not connect to LDAP server');
+		}
+
+		$this->object->base_dn  = 'dc=joomla,dc=org';
+		$this->object->users_dn = 'cn=[username],dc=joomla,dc=org';
+
+		if (!$this->object->bind('admin', 'joomla'))
+		{
+			$this->markTestSkipped('Could not bind to LDAP server');
+		}
+
+		$this->assertTrue($this->object->delete('cn=Michael Babker,dc=joomla,dc=org'), 'The entry was not deleted');
+
+		// Reset
+		$this->object->create(
+			'cn=Michael Babker,dc=joomla,dc=org',
+			array(
+				'objectClass' => array(
+					'inetOrgPerson',
+					'organizationalPerson',
+					'person',
+					'top',
+				),
+				'cn'          => array(
+					'Michael Babker',
+				),
+				'sn'          => array(
+					'mbabker',
+				),
+				'mail'        => array(
+					'michael.babker@joomla.org',
+				),
+				'ou'          => array(
+					'People',
+					'Maintainers',
+				),
+				'givenName'   => array(
+					'Michael Babker',
+				),
+				'description' => array(
+					'Framework Maintainer, CMS Release Lead, Production Department Coordinator',
+				),
+			)
+		);
 	}
 
 	/**

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -24,7 +24,7 @@ class LdapClientTest extends TestCase
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 *
-	 * @return void
+	 * @return  void
 	 */
 	protected function setUp()
 	{
@@ -39,6 +39,19 @@ class LdapClientTest extends TestCase
 	}
 
 	/**
+	 * Tears down the fixture, for example, close a network connection.
+	 * This method is called after a test is executed.
+	 *
+	 * @return  void
+	 */
+	protected function tearDown()
+	{
+		unset($this->object);
+
+		parent::tearDown();
+	}
+
+	/**
 	 * @covers  Joomla\Ldap\Ldap::connect
 	 */
 	public function testConnect()
@@ -47,42 +60,36 @@ class LdapClientTest extends TestCase
 	}
 
 	/**
-	 * Test...
-	 *
-	 * @todo Implement testClose().
-	 *
-	 * @return void
+	 * @covers  Joomla\Ldap\Ldap::setDn
+	 * @uses    Joomla\Ldap\Ldap::getDn
 	 */
-	public function testClose()
+	public function testSetDnWithNoUserDn()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$dn = 'cn=admin,dc=joomla,dc=org';
+
+		$this->object->setDn($dn);
+
+		$this->assertSame($dn, $this->object->getDn());
 	}
 
 	/**
-	 * Test...
-	 *
-	 * @todo Implement testSetDn().
-	 *
-	 * @return void
+	 * @covers  Joomla\Ldap\Ldap::setDn
+	 * @uses    Joomla\Ldap\Ldap::getDn
 	 */
-	public function testSetDn()
+	public function testSetDnWithUserDn()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->object->setDn('uid=[username],cn=admin,dc=joomla,dc=org');
+		$this->object->setDn('admin');
+
+		$this->assertSame('uid=admin,cn=admin,dc=joomla,dc=org', $this->object->getDn());
 	}
 
 	/**
-	 * Test...
-	 *
-	 * @todo Implement testGetDn().
-	 *
-	 * @return void
+	 * @covers  Joomla\Ldap\Ldap::getDn
 	 */
 	public function testGetDn()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->assertNull($this->object->getDn());
 	}
 
 	/**
@@ -94,6 +101,12 @@ class LdapClientTest extends TestCase
 	 */
 	public function testAnonymous_bind()
 	{
+		if (!$this->object->connect())
+		{
+			$this->markTestSkipped('Could not connect to LDAP server');
+		}
+
+		var_dump($this->object->anonymous_bind());
 		// Remove the following lines when you implement this test.
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -106,7 +106,12 @@ class LdapClientTest extends TestCase
 	 */
 	public function testAnonymousBinding()
 	{
-		$this->markTestSkipped('Not connecting correctly on Travis CI environment');
+		if (!$this->object->connect())
+		{
+			$this->markTestSkipped('Could not connect to LDAP server');
+		}
+
+		$this->assertTrue($this->object->anonymous_bind(), 'LDAP connection failed: ' . $this->object->getErrorMsg());
 	}
 
 	/**
@@ -125,9 +130,7 @@ class LdapClientTest extends TestCase
 
 		$this->object->setDn('cn=admin,dc=joomla,dc=org');
 
-		var_dump($this->object->bind(null, 'joomla'));
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->assertTrue($this->object->bind(null, 'joomla'), 'LDAP connection failed: ' . $this->object->getErrorMsg());
 	}
 
 	/**

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -160,22 +160,60 @@ class LdapClientTest extends TestCase
 			$this->markTestSkipped('Could not bind to LDAP server');
 		}
 
-		var_dump($this->object->simple_search('objectclass=person'));
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->assertCount(1, $this->object->simple_search('objectclass=person'), 'The search did not return the expected number of results');
 	}
 
 	/**
-	 * Test...
+	 * @testdox  A search is performed without an override of the base DN
 	 *
-	 * @todo Implement testSearch().
-	 *
-	 * @return void
+	 * @covers  Joomla\Ldap\Ldap::simple_search
+	 * @uses    Joomla\Ldap\Ldap::bind
+	 * @uses    Joomla\Ldap\Ldap::connect
+	 * @uses    Joomla\Ldap\Ldap::search
+	 * @uses    Joomla\Ldap\Ldap::setDn
 	 */
-	public function testSearch()
+	public function testSearchWithoutDnOverride()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		if (!$this->object->connect())
+		{
+			$this->markTestSkipped('Could not connect to LDAP server');
+		}
+
+		$this->object->base_dn  = 'dc=joomla,dc=org';
+		$this->object->users_dn = 'cn=[username],dc=joomla,dc=org';
+
+		if (!$this->object->bind('admin', 'joomla'))
+		{
+			$this->markTestSkipped('Could not bind to LDAP server');
+		}
+
+		$this->assertCount(1, $this->object->search(array('(objectclass=person)')), 'The search did not return the expected number of results');
+	}
+
+	/**
+	 * @testdox  A search is performed with an override of the base DN
+	 *
+	 * @covers  Joomla\Ldap\Ldap::simple_search
+	 * @uses    Joomla\Ldap\Ldap::bind
+	 * @uses    Joomla\Ldap\Ldap::connect
+	 * @uses    Joomla\Ldap\Ldap::search
+	 * @uses    Joomla\Ldap\Ldap::setDn
+	 */
+	public function testSearchWithDnOverride()
+	{
+		if (!$this->object->connect())
+		{
+			$this->markTestSkipped('Could not connect to LDAP server');
+		}
+
+		$this->object->users_dn = 'cn=[username],dc=joomla,dc=org';
+
+		if (!$this->object->bind('admin', 'joomla'))
+		{
+			$this->markTestSkipped('Could not bind to LDAP server');
+		}
+
+		$this->assertCount(1, $this->object->search(array('(objectclass=person)'), 'dc=joomla,dc=org'), 'The search did not return the expected number of results');
 	}
 
 	/**

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -351,7 +351,9 @@ class LdapClientTest extends TestCase
 			$this->markTestSkipped('Could not bind to LDAP server');
 		}
 
-		var_dump($this->object->read('(objectclass=*),dc=joomla,dc=org'));
+		$result = $this->object->read('(objectclass=person),cn=Michael Babker,dc=joomla,dc=org');
+
+		$this->assertSame(1, $result['count'], 'The expected number of entries were not read');
 	}
 
 	/**

--- a/Tests/LdapClientTest.php
+++ b/Tests/LdapClientTest.php
@@ -131,9 +131,7 @@ class LdapClientTest extends TestCase
 			$this->markTestSkipped('Could not connect to LDAP server');
 		}
 
-		$this->object->setDn('cn=admin,dc=joomla,dc=org');
-
-		$this->assertTrue($this->object->bind(null, 'joomla'), 'LDAP connection failed: ' . $this->object->getErrorMsg());
+		$this->assertTrue($this->object->bind('cn=admin,dc=joomla,dc=org', 'joomla'), 'LDAP connection failed: ' . $this->object->getErrorMsg());
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "symfony/polyfill-php56": "~1.0"
     },
     "require-dev": {
+        "joomla/registry": "^1.4.5|~2.0",
         "phpunit/phpunit": "^4.8.35|^5.4.3|~6.0",
         "squizlabs/php_codesniffer": "1.*"
     },
@@ -24,6 +25,7 @@
             "Joomla\\Ldap\\Tests\\": "Tests/"
         }
     },
+    "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
             "dev-master": "1.x-dev"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
 	<php>
 		<env name="LDAP_HOST" value="127.0.0.1"/>
 		<env name="LDAP_PORT" value="3389"/>
+		<env name="LDAP_V3" value="1"/>
 	</php>
 
 	<testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php" colors="false">
+	<php>
+		<env name="LDAP_HOST" value="127.0.0.1"/>
+		<env name="LDAP_PORT" value="3389"/>
+	</php>
+
 	<testsuites>
 		<testsuite name="Unit">
 			<directory>Tests</directory>

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -506,6 +506,7 @@ class LdapClient
 
 		$base = substr($dn, strpos($dn, ',') + 1);
 		$cn = substr($dn, 0, strpos($dn, ','));
+		var_dump($base, $cn);
 		$result = @ldap_read($this->resource, $base, $cn);
 
 		if ($result === false)

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -285,8 +285,12 @@ class LdapClient
 		}
 
 		$this->setDn($username, $nosub);
-var_dump($this->getDn(), $password);
-		return @ldap_bind($this->resource, $this->getDn(), $password);
+
+		$bound = @ldap_bind($this->resource, $this->getDn(), $password);
+
+		$this->isBound = $bound;
+
+		return $bound;
 	}
 
 	/**

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -271,9 +271,8 @@ class LdapClient
 		}
 
 		$this->setDn($username, $nosub);
-		$bindResult = @ldap_bind($this->resource, $this->getDn(), $password);
 
-		return $bindResult;
+		return @ldap_bind($this->resource, $this->getDn(), $password);
 	}
 
 	/**

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -124,6 +124,16 @@ class LdapClient
 	}
 
 	/**
+	 * Class destructor.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __destruct()
+	{
+		$this->close();
+	}
+
+	/**
 	 * Connect to server
 	 *
 	 * @return  boolean  True if successful
@@ -179,7 +189,12 @@ class LdapClient
 	 */
 	public function close()
 	{
-		@ ldap_close($this->resource);
+		if ($this->resource && is_resource($this->resource))
+		{
+			@ldap_close($this->resource);
+		}
+
+		$this->resource = null;
 	}
 
 	/**
@@ -229,9 +244,7 @@ class LdapClient
 	 */
 	public function anonymous_bind()
 	{
-		$bindResult = @ldap_bind($this->resource);
-
-		return $bindResult;
+		return @ldap_bind($this->resource);
 	}
 
 	/**

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -419,6 +419,11 @@ class LdapClient
 	 */
 	public function replace($dn, $attribute)
 	{
+		if (!$this->isBound || !$this->isConnected())
+		{
+			return false;
+		}
+
 		return @ldap_mod_replace($this->resource, $dn, $attribute);
 	}
 
@@ -434,6 +439,11 @@ class LdapClient
 	 */
 	public function modify($dn, $attribute)
 	{
+		if (!$this->isBound || !$this->isConnected())
+		{
+			return false;
+		}
+
 		return @ldap_modify($this->resource, $dn, $attribute);
 	}
 
@@ -449,9 +459,12 @@ class LdapClient
 	 */
 	public function remove($dn, $attribute)
 	{
-		$resource = $this->resource;
+		if (!$this->isBound || !$this->isConnected())
+		{
+			return false;
+		}
 
-		return @ldap_mod_del($resource, $dn, $attribute);
+		return @ldap_mod_del($this->resource, $dn, $attribute);
 	}
 
 	/**
@@ -467,6 +480,11 @@ class LdapClient
 	 */
 	public function compare($dn, $attribute, $value)
 	{
+		if (!$this->isBound || !$this->isConnected())
+		{
+			return false;
+		}
+
 		return @ldap_compare($this->resource, $dn, $attribute, $value);
 	}
 

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -506,7 +506,6 @@ class LdapClient
 
 		$base = substr($dn, strpos($dn, ',') + 1);
 		$cn = substr($dn, 0, strpos($dn, ','));
-		var_dump($base, $cn);
 		$result = @ldap_read($this->resource, $base, $cn);
 
 		if ($result === false)

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -568,6 +568,11 @@ class LdapClient
 	 */
 	public function add($dn, array $entry)
 	{
+		if (!$this->isBound || !$this->isConnected())
+		{
+			return false;
+		}
+
 		return @ldap_mod_add($this->resource, $dn, $entry);
 	}
 
@@ -585,6 +590,11 @@ class LdapClient
 	 */
 	public function rename($dn, $newdn, $newparent, $deleteolddn)
 	{
+		if (!$this->isBound || !$this->isConnected())
+		{
+			return false;
+		}
+
 		return @ldap_rename($this->resource, $dn, $newdn, $newparent, $deleteolddn);
 	}
 

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -499,10 +499,15 @@ class LdapClient
 	 */
 	public function read($dn)
 	{
+		if (!$this->isBound || !$this->isConnected())
+		{
+			return false;
+		}
+
 		$base = substr($dn, strpos($dn, ',') + 1);
 		$cn = substr($dn, 0, strpos($dn, ','));
 		$result = @ldap_read($this->resource, $base, $cn);
-
+var_dump($result);
 		if ($result)
 		{
 			return @ldap_get_entries($this->resource, $result);

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -270,11 +270,17 @@ class LdapClient
 	 */
 	public function anonymous_bind()
 	{
-		$bound = @ldap_bind($this->resource);
+		if (!$this->isConnected())
+		{
+			if (!$this->connect())
+			{
+				return false;
+			}
+		}
 
-		$this->isBound = $bound;
+		$this->isBound = @ldap_bind($this->resource);
 
-		return $bound;
+		return $this->isBound;
 	}
 
 	/**
@@ -290,6 +296,14 @@ class LdapClient
 	 */
 	public function bind($username = null, $password = null, $nosub = 0)
 	{
+		if (!$this->isConnected())
+		{
+			if (!$this->connect())
+			{
+				return false;
+			}
+		}
+
 		if (is_null($username))
 		{
 			$username = $this->username;
@@ -302,11 +316,9 @@ class LdapClient
 
 		$this->setDn($username, $nosub);
 
-		$bound = @ldap_bind($this->resource, $this->getDn(), $password);
+		$this->isBound = @ldap_bind($this->resource, $this->getDn(), $password);
 
-		$this->isBound = $bound;
-
-		return $bound;
+		return $this->isBound;
 	}
 
 	/**

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -507,15 +507,13 @@ class LdapClient
 		$base = substr($dn, strpos($dn, ',') + 1);
 		$cn = substr($dn, 0, strpos($dn, ','));
 		$result = @ldap_read($this->resource, $base, $cn);
-var_dump($result);
-		if ($result)
+
+		if ($result === false)
 		{
-			return @ldap_get_entries($this->resource, $result);
+			return false;
 		}
-		else
-		{
-			return $result;
-		}
+
+		return @ldap_get_entries($this->resource, $result);
 	}
 
 	/**

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -527,6 +527,11 @@ class LdapClient
 	 */
 	public function delete($dn)
 	{
+		if (!$this->isBound || !$this->isConnected())
+		{
+			return false;
+		}
+
 		return @ldap_delete($this->resource, $dn);
 	}
 

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -547,6 +547,11 @@ class LdapClient
 	 */
 	public function create($dn, array $entries)
 	{
+		if (!$this->isBound || !$this->isConnected())
+		{
+			return false;
+		}
+
 		return @ldap_add($this->resource, $dn, $entries);
 	}
 

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -96,6 +96,14 @@ class LdapClient
 	private $dn = null;
 
 	/**
+	 * Flag tracking whether the connection has been bound
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $isBound = false;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   object  $configObj  An object of configuration variables
@@ -191,6 +199,8 @@ class LdapClient
 	{
 		if ($this->resource && is_resource($this->resource))
 		{
+			$this->unbind();
+
 			@ldap_close($this->resource);
 		}
 
@@ -238,13 +248,17 @@ class LdapClient
 	/**
 	 * Anonymously binds to LDAP directory
 	 *
-	 * @return  array
+	 * @return  boolean
 	 *
 	 * @since   1.0
 	 */
 	public function anonymous_bind()
 	{
-		return @ldap_bind($this->resource);
+		$bound = @ldap_bind($this->resource);
+
+		$this->isBound = $bound;
+
+		return $bound;
 	}
 
 	/**
@@ -271,8 +285,25 @@ class LdapClient
 		}
 
 		$this->setDn($username, $nosub);
-
+var_dump($this->getDn(), $password);
 		return @ldap_bind($this->resource, $this->getDn(), $password);
+	}
+
+	/**
+	 * Unbinds from the LDAP directory
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function unbind()
+	{
+		if ($this->isBound && $this->resource && is_resource($this->resource))
+		{
+			return @ldap_unbind($this->resource);
+		}
+
+		return true;
 	}
 
 	/**
@@ -282,7 +313,7 @@ class LdapClient
 	 *
 	 * @return  array  Search results
 	 *
-	 * @since  1.0
+	 * @since   1.0
 	 */
 	public function simple_search($search)
 	{

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -197,7 +197,7 @@ class LdapClient
 	 */
 	public function close()
 	{
-		if ($this->resource && is_resource($this->resource))
+		if ($this->isConnected())
 		{
 			$this->unbind();
 
@@ -345,6 +345,11 @@ class LdapClient
 	public function search(array $filters, $dnoverride = null, array $attributes = array())
 	{
 		$result = array();
+
+		if (!$this->isBound || !$this->isConnected())
+		{
+			return $result;
+		}
 
 		if ($dnoverride)
 		{
@@ -578,6 +583,18 @@ class LdapClient
 	public function getErrorMsg()
 	{
 		return @ldap_error($this->resource);
+	}
+
+	/**
+	 * Check if the connection is established
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function isConnected()
+	{
+		return $this->resource && is_resource($this->resource);
 	}
 
 	/**

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -617,12 +617,17 @@ class LdapClient
 	/**
 	 * Returns the error message
 	 *
-	 * @return  string   error message
+	 * @return  string
 	 *
 	 * @since   1.0
 	 */
 	public function getErrorMsg()
 	{
+		if (!$this->isBound || !$this->isConnected())
+		{
+			return '';
+		}
+
 		return @ldap_error($this->resource);
 	}
 
@@ -720,7 +725,9 @@ class LdapClient
 			'TCP6',
 			'Reserved (12)',
 			'URL',
-			'Count');
+			'Count'
+		);
+
 		$len = strlen($networkaddress);
 
 		if ($len > 0)
@@ -757,7 +764,7 @@ class LdapClient
 	 * @param   string  $password  Clear text password to encrypt
 	 * @param   string  $type      Type of password hash, either md5 or SHA
 	 *
-	 * @return  string   Encrypted password
+	 * @return  string
 	 *
 	 * @since   1.0
 	 */

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Part of the Joomla Framework Client Package
+ * Part of the Joomla Framework LDAP Package
  *
  * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
@@ -16,81 +16,105 @@ namespace Joomla\Ldap;
 class LdapClient
 {
 	/**
-	 * @var    string  Hostname of LDAP server
+	 * Hostname of LDAP server
+	 *
+	 * @var    string
 	 * @since  1.0
 	 */
 	public $host = null;
 
 	/**
-	 * @var    bool  Authorization Method to use
+	 * Authorization Method to use
+	 *
+	 * @var    boolean
 	 * @since  1.0
 	 */
 	public $auth_method = null;
 
 	/**
-	 * @var    int  Port of LDAP server
+	 * Port of LDAP server
+	 *
+	 * @var    integer
 	 * @since  1.0
 	 */
 	public $port = null;
 
 	/**
-	 * @var    string  Base DN (e.g. o=MyDir)
+	 * Base DN (e.g. o=MyDir)
+	 *
+	 * @var    string
 	 * @since  1.0
 	 */
 	public $base_dn = null;
 
 	/**
-	 * @var    string  User DN (e.g. cn=Users,o=MyDir)
+	 * User DN (e.g. cn=Users,o=MyDir)
+	 *
+	 * @var    string
 	 * @since  1.0
 	 */
 	public $users_dn = null;
 
 	/**
-	 * @var    string  Search String
+	 * Search String
+	 *
+	 * @var    string
 	 * @since  1.0
 	 */
 	public $search_string = null;
 
 	/**
-	 * @var    boolean  Use LDAP Version 3
+	 * Use LDAP Version 3
+	 *
+	 * @var    boolean
 	 * @since  1.0
 	 */
 	public $use_ldapV3 = null;
 
 	/**
-	 * @var    boolean  No referrals (server transfers)
+	 * No referrals (server transfers)
+	 *
+	 * @var    boolean
 	 * @since  1.0
 	 */
 	public $no_referrals = null;
 
 	/**
-	 * @var    boolean  Negotiate TLS (encrypted communications)
+	 * Negotiate TLS (encrypted communications)
+	 *
+	 * @var    boolean
 	 * @since  1.0
 	 */
 	public $negotiate_tls = null;
 
 	/**
-	 * @var    string  Username to connect to server
+	 * Username to connect to server
+	 *
+	 * @var    string
 	 * @since  1.0
 	 */
 	public $username = null;
 
 	/**
+	 * Password to connect to server
 	 *
-	 * @var    string  Password to connect to server
+	 * @var    string
 	 * @since  1.0
 	 */
 	public $password = null;
 
 	/**
-	 * @var    mixed  LDAP Resource Identifier
+	 * LDAP Resource Identifier
+	 *
+	 * @var    resource
 	 * @since  1.0
 	 */
 	private $resource = null;
 
 	/**
+	 * Current DN
 	 *
-	 * @var    string  Current DN
+	 * @var    string
 	 * @since  1.0
 	 */
 	private $dn = null;
@@ -142,9 +166,9 @@ class LdapClient
 	}
 
 	/**
-	 * Connect to server
+	 * Connect to an LDAP server
 	 *
-	 * @return  boolean  True if successful
+	 * @return  boolean
 	 *
 	 * @since   1.0
 	 */
@@ -157,35 +181,27 @@ class LdapClient
 
 		$this->resource = @ ldap_connect($this->host, $this->port);
 
-		if ($this->resource)
-		{
-			if ($this->use_ldapV3)
-			{
-				if (!@ldap_set_option($this->resource, LDAP_OPT_PROTOCOL_VERSION, 3))
-				{
-					return false;
-				}
-			}
-
-			if (!@ldap_set_option($this->resource, LDAP_OPT_REFERRALS, (int) $this->no_referrals))
-			{
-				return false;
-			}
-
-			if ($this->negotiate_tls)
-			{
-				if (!@ldap_start_tls($this->resource))
-				{
-					return false;
-				}
-			}
-
-			return true;
-		}
-		else
+		if (!$this->resource)
 		{
 			return false;
 		}
+
+		if ($this->use_ldapV3 && !@ldap_set_option($this->resource, LDAP_OPT_PROTOCOL_VERSION, 3))
+		{
+			return false;
+		}
+
+		if (!@ldap_set_option($this->resource, LDAP_OPT_REFERRALS, (int) $this->no_referrals))
+		{
+			return false;
+		}
+
+		if ($this->negotiate_tls && !@ldap_start_tls($this->resource))
+		{
+			return false;
+		}
+
+		return true;
 	}
 
 	/**
@@ -234,9 +250,9 @@ class LdapClient
 	}
 
 	/**
-	 * Get the DN
+	 * Get the configured DN
 	 *
-	 * @return  string  The current dn
+	 * @return  string
 	 *
 	 * @since   1.0
 	 */
@@ -360,13 +376,11 @@ class LdapClient
 			$dn = $this->base_dn;
 		}
 
-		$resource = $this->resource;
-
 		foreach ($filters as $search_filter)
 		{
-			$search_result = @ldap_search($resource, $dn, $search_filter, $attributes);
+			$search_result = @ldap_search($this->resource, $dn, $search_filter, $attributes);
 
-			if ($search_result && ($count = @ldap_count_entries($resource, $search_result)) > 0)
+			if ($search_result && ($count = @ldap_count_entries($this->resource, $search_result)) > 0)
 			{
 				for ($i = 0; $i < $count; $i++)
 				{
@@ -374,15 +388,15 @@ class LdapClient
 
 					if (!$i)
 					{
-						$firstentry = @ldap_first_entry($resource, $search_result);
+						$firstentry = @ldap_first_entry($this->resource, $search_result);
 					}
 					else
 					{
-						$firstentry = @ldap_next_entry($resource, $firstentry);
+						$firstentry = @ldap_next_entry($this->resource, $firstentry);
 					}
 
 					// Load user-specified attributes
-					$result_array = @ldap_get_attributes($resource, $firstentry);
+					$result_array = @ldap_get_attributes($this->resource, $firstentry);
 
 					// LDAP returns an array of arrays, fit this into attributes result array
 					foreach ($result_array as $ki => $ai)
@@ -399,7 +413,7 @@ class LdapClient
 						}
 					}
 
-					$result[$i]['dn'] = @ldap_get_dn($resource, $firstentry);
+					$result[$i]['dn'] = @ldap_get_dn($this->resource, $firstentry);
 				}
 			}
 		}
@@ -408,12 +422,12 @@ class LdapClient
 	}
 
 	/**
-	 * Replace an entry and return a true or false result
+	 * Replace attribute values with new ones
 	 *
 	 * @param   string  $dn         The DN which contains the attribute you want to replace
 	 * @param   string  $attribute  The attribute values you want to replace
 	 *
-	 * @return  mixed  result of comparison (true, false, -1 on error)
+	 * @return  boolean
 	 *
 	 * @since   1.0
 	 */
@@ -428,12 +442,12 @@ class LdapClient
 	}
 
 	/**
-	 * Modifies an entry and return a true or false result
+	 * Modify an LDAP entry
 	 *
 	 * @param   string  $dn         The DN which contains the attribute you want to modify
 	 * @param   string  $attribute  The attribute values you want to modify
 	 *
-	 * @return  mixed  result of comparison (true, false, -1 on error)
+	 * @return  boolean
 	 *
 	 * @since   1.0
 	 */
@@ -448,12 +462,12 @@ class LdapClient
 	}
 
 	/**
-	 * Removes attribute value from given dn and return a true or false result
+	 * Delete attribute values from current attributes
 	 *
 	 * @param   string  $dn         The DN which contains the attribute you want to remove
 	 * @param   string  $attribute  The attribute values you want to remove
 	 *
-	 * @return  mixed  result of comparison (true, false, -1 on error)
+	 * @return  boolean
 	 *
 	 * @since   1.0
 	 */
@@ -468,13 +482,13 @@ class LdapClient
 	}
 
 	/**
-	 * Compare an entry and return a true or false result
+	 * Compare value of attribute found in entry specified with DN
 	 *
 	 * @param   string  $dn         The DN which contains the attribute you want to compare
 	 * @param   string  $attribute  The attribute whose value you want to compare
 	 * @param   string  $value      The value you want to check against the LDAP attribute
 	 *
-	 * @return  mixed  result of comparison (true, false, -1 on error)
+	 * @return  boolean|integer  Boolean result of the comparison or -1 on error
 	 *
 	 * @since   1.0
 	 */
@@ -489,11 +503,11 @@ class LdapClient
 	}
 
 	/**
-	 * Read all or specified attributes of given dn
+	 * Read attributes of a given DN
 	 *
 	 * @param   string  $dn  The DN of the object you want to read
 	 *
-	 * @return  mixed  array of attributes or -1 on error
+	 * @return  array|boolean  Array of attributes for the given DN or boolean false on failure
 	 *
 	 * @since   1.0
 	 */
@@ -517,11 +531,11 @@ class LdapClient
 	}
 
 	/**
-	 * Deletes a given DN from the tree
+	 * Delete an entry from a directory
 	 *
 	 * @param   string  $dn  The DN of the object you want to delete
 	 *
-	 * @return  boolean  Result of operation
+	 * @return  boolean
 	 *
 	 * @since   1.0
 	 */
@@ -536,12 +550,12 @@ class LdapClient
 	}
 
 	/**
-	 * Create a new DN
+	 * Add entries to LDAP directory
 	 *
 	 * @param   string  $dn       The DN where you want to put the object
 	 * @param   array   $entries  An array of arrays describing the object to add
 	 *
-	 * @return  boolean  Result of operation
+	 * @return  boolean
 	 *
 	 * @since   1.0
 	 */
@@ -556,13 +570,12 @@ class LdapClient
 	}
 
 	/**
-	 * Add an attribute to the given DN
-	 * Note: DN has to exist already
+	 * Add attribute values to current attributes
 	 *
 	 * @param   string  $dn     The DN of the entry to add the attribute
 	 * @param   array   $entry  An array of arrays with attributes to add
 	 *
-	 * @return  boolean   Result of operation
+	 * @return  boolean
 	 *
 	 * @since   1.0
 	 */
@@ -577,14 +590,14 @@ class LdapClient
 	}
 
 	/**
-	 * Rename the entry
+	 * Modify the name of an entry
 	 *
 	 * @param   string   $dn           The DN of the entry at the moment
 	 * @param   string   $newdn        The DN of the entry should be (only cn=newvalue)
 	 * @param   string   $newparent    The full DN of the parent (null by default)
 	 * @param   boolean  $deleteolddn  Delete the old values (default)
 	 *
-	 * @return  boolean  Result of operation
+	 * @return  boolean
 	 *
 	 * @since   1.0
 	 */
@@ -615,7 +628,7 @@ class LdapClient
 	}
 
 	/**
-	 * Returns the error message
+	 * Return the LDAP error message of the last LDAP command
 	 *
 	 * @return  string
 	 *
@@ -648,7 +661,7 @@ class LdapClient
 	 *
 	 * @param   string  $ip  IP Address (e.g. xxx.xxx.xxx.xxx)
 	 *
-	 * @return  string  Net address
+	 * @return  string
 	 *
 	 * @since   1.0
 	 */
@@ -773,15 +786,11 @@ class LdapClient
 		switch (strtolower($type))
 		{
 			case 'sha':
-				$userpassword = '{SHA}' . base64_encode(pack('H*', sha1($password)));
-				break;
+				return '{SHA}' . base64_encode(pack('H*', sha1($password)));
 
 			case 'md5':
 			default:
-				$userpassword = '{MD5}' . base64_encode(pack('H*', md5($password)));
-				break;
+				return '{MD5}' . base64_encode(pack('H*', md5($password)));
 		}
-
-		return $userpassword;
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #6

### Summary of Changes

- Adds a functional test class covering the LdapClient
- Adds tracking state to make sure the connection is bound
- Adds a destructor to make sure the connection is closed when the object destroyed
- Adds checks to make sure the connection is established and bound when needed since we cannot lazy bind

### Testing Instructions

Either put some trust in a green CI build or try to set up a LDAP server and use the client