### PR TITLE
Added support for debug LDAP and the option of ignoring a self-signed…

### DIFF
--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -94,7 +94,7 @@ class LdapClient
 	 * @var    boolean
 	 * @since  __DEPLOY_VERSION__
 	 */
-	public $ignore_reqcert_tls = null;
+	public $ignore_reqcert_tls;
 
 	/**
 	 * Enable LDAP debug (encrypted communications)
@@ -102,7 +102,7 @@ class LdapClient
 	 * @var    boolean
 	 * @since  __DEPLOY_VERSION__
 	 */
-	public $ldap_debug = null;
+	public $ldap_debug;
 
 	/**
 	 * Username to connect to server

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -102,7 +102,7 @@ class LdapClient
 	 * @var    boolean
 	 * @since  __DEPLOY_VERSION__
 	 */
-	 public $ldap_debug = null;
+	public $ldap_debug = null;
 
 	/**
 	 * Username to connect to server

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -88,20 +88,20 @@ class LdapClient
 	 */
 	public $negotiate_tls;
 
-        /**
+	/**
 	 * Ignore TLS Certificate (encrypted communications)
-         *
-         * @var    boolean
-         * @since  __DEPLOY_VERSION__
-         */
-	 public $ignore_reqcert_tls = null;
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $ignore_reqcert_tls = null;
 
-        /**
+	/**
 	 * Enable LDAP debug (encrypted communications)
-         *
-         * @var    boolean
-         * @since  __DEPLOY_VERSION__
-         */
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
 	 public $ldap_debug = null;
 
 	/**

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -97,7 +97,7 @@ class LdapClient
 	public $ignore_reqcert_tls;
 
 	/**
-	 * Enable LDAP debug (encrypted communications)
+	 * Enable LDAP debug
 	 *
 	 * @var    boolean
 	 * @since  __DEPLOY_VERSION__

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -203,7 +203,7 @@ class LdapClient
 
 		if ($this->ldap_debug)
 		{
-			ldap_set_option(NULL, LDAP_OPT_DEBUG_LEVEL, 7);
+			ldap_set_option(null, LDAP_OPT_DEBUG_LEVEL, 7);
 		}
 
 		$this->resource = ldap_connect($this->host, $this->port);

--- a/src/LdapClient.php
+++ b/src/LdapClient.php
@@ -88,6 +88,22 @@ class LdapClient
 	 */
 	public $negotiate_tls;
 
+        /**
+	 * Ignore TLS Certificate (encrypted communications)
+         *
+         * @var    boolean
+         * @since  __DEPLOY_VERSION__
+         */
+	 public $ignore_reqcert_tls = null;
+
+        /**
+	 * Enable LDAP debug (encrypted communications)
+         *
+         * @var    boolean
+         * @since  __DEPLOY_VERSION__
+         */
+	 public $ldap_debug = null;
+
 	/**
 	 * Username to connect to server
 	 *
@@ -178,6 +194,16 @@ class LdapClient
 		if ($this->host == '')
 		{
 			return false;
+		}
+
+		if ($this->ignore_reqcert_tls)
+		{
+			putenv('LDAPTLS_REQCERT=never');
+		}
+
+		if ($this->ldap_debug)
+		{
+			ldap_set_option(NULL, LDAP_OPT_DEBUG_LEVEL, 7);
 		}
 
 		$this->resource = ldap_connect($this->host, $this->port);


### PR DESCRIPTION
… certificate on the server.

### Summary of Changes
Added patches for connecting to AD-server with self-signed certificates.
Added enabling a debug option for LDAP connections.

### Testing Instructions
Just install and enable the Ignore Certificate option.
Just enable the debug-option and get more information about the LDAP-connection.

### Documentation Changes Required
Option:
"Ignore Certificate"
Desc:
When enabled ignore the server certificate, this is useful when running for example Samba 4 with a self-signed certificate.

Option:
"Enable Debug"
Desc:
When enabled the LDAP-connection will log the transactions with LDAP-debug setting 7.